### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "react-router-dom": "^6.22.1",
     "react-scripts": "5.0.1",
     "sort-by": "^1.2.0",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "dompurify": "^3.2.3"
   },
   "scripts": {
     "dev": "react-scripts start",

--- a/frontend/src/components/KnowledgeBase.js
+++ b/frontend/src/components/KnowledgeBase.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import DOMPurify from 'dompurify';
 import { AuthDisplay } from "./AuthDisplay";
 import Navbar from "./Navbar";
 
@@ -15,7 +16,7 @@ function KnowledgeBase() {
 
   const change = (event) => {
     const newVal = val.split(" ").join("+");
-    setVal(event.target.value);
+    setVal(DOMPurify.sanitize(event.target.value));
     // alert(val.split(' ').join('+'));
   };
 


### PR DESCRIPTION
Fixes [https://github.com/Joshua-Ludolf/FossilFinances/security/code-scanning/2](https://github.com/Joshua-Ludolf/FossilFinances/security/code-scanning/2)

To fix this issue, we need to ensure that the user input is properly sanitized before being used in the `href` attribute. One way to achieve this is by using a library like `DOMPurify` to sanitize the input. This will help prevent any malicious scripts from being executed.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the file.
3. Use `DOMPurify` to sanitize the user input before setting it to the `val` state variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
